### PR TITLE
상품페이지, 장바구니에서 헤더와 푸터가 없어지는 문제 수정했습니다.

### DIFF
--- a/cart/index.html
+++ b/cart/index.html
@@ -1,110 +1,115 @@
 <!DOCTYPE html>
 <html lang="ko">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>장바구니 | HODU</title>
-    <link rel="stylesheet" href="../assets/css/reset.css" />
-    <link rel="stylesheet" href="../assets/css/root.css" />
-    <link rel="stylesheet" href="../assets/css/font.css" />
-    <link rel="stylesheet" href="../assets/css/common.css" />
-    <link rel="stylesheet" href="../assets/css/pages/cart.css" />
-  </head>
-  <body>
-    <!-- Header -->
-    <div id="header-container"></div>
 
-    <!-- Main Content -->
-    <main class="cart-main">
-      <h2 class="cart-title">장바구니</h2>
+<head>
+  <meta charset="UTF-8" />
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>장바구니 | HODU</title>
+  <link rel="stylesheet" href="../assets/css/reset.css" />
+  <link rel="stylesheet" href="../assets/css/root.css" />
+  <link rel="stylesheet" href="../assets/css/font.css" />
+  <link rel="stylesheet" href="../assets/css/common.css" />
+  <link rel="stylesheet" href="../assets/css/pages/cart.css" />
+</head>
 
-      <!-- Cart Table Header -->
-      <div class="cart-header-bar">
-        <div class="container cart-header-content">
-          <label class="custom-checkbox header-checkbox">
-            <input type="checkbox" id="selectAll" checked />
-            <span class="checkmark"></span>
-          </label>
-          <span class="header-label product-info-label">상품정보</span>
-          <span class="header-label quantity-label">수량</span>
-          <span class="header-label price-label">상품금액</span>
-        </div>
+<body>
+  <!-- Header -->
+  <header id="header-container"></header>
+
+  <!-- Main Content -->
+  <main class="cart-main">
+    <h2 class="cart-title">장바구니</h2>
+
+    <!-- Cart Table Header -->
+    <div class="cart-header-bar">
+      <div class="container cart-header-content">
+        <label class="custom-checkbox header-checkbox">
+          <input type="checkbox" id="selectAll" checked />
+          <span class="checkmark"></span>
+        </label>
+        <span class="header-label product-info-label">상품정보</span>
+        <span class="header-label quantity-label">수량</span>
+        <span class="header-label price-label">상품금액</span>
+      </div>
+    </div>
+
+    <!-- Cart Items Container -->
+    <div class="container">
+      <div id="cartItems" class="cart-items-list">
+        <!-- 상품이 담긴 경우 동적으로 렌더링 -->
       </div>
 
-      <!-- Cart Items Container -->
+      <!-- Empty Cart State -->
+      <div id="emptyCart" class="empty-cart" style="display: none;">
+        <p class="empty-cart-title">장바구니에 담긴 상품이 없습니다.</p>
+        <p class="empty-cart-text">원하는 상품을 장바구니에 담아보세요!</p>
+      </div>
+    </div>
+
+    <!-- Summary Section -->
+    <div class="cart-summary-wrapper">
       <div class="container">
-        <div id="cartItems" class="cart-items-list">
-          <!-- 상품이 담긴 경우 동적으로 렌더링 -->
-        </div>
-
-        <!-- Empty Cart State -->
-        <div id="emptyCart" class="empty-cart" style="display: none;">
-          <p class="empty-cart-title">장바구니에 담긴 상품이 없습니다.</p>
-          <p class="empty-cart-text">원하는 상품을 장바구니에 담아보세요!</p>
-        </div>
-      </div>
-
-      <!-- Summary Section -->
-      <div class="cart-summary-wrapper">
-        <div class="container">
-          <div class="cart-summary">
-            <div class="summary-item">
-              <span class="summary-label">총 상품금액</span>
-              <span class="summary-value" id="totalProductPrice">0<span class="unit">원</span></span>
-            </div>
-            <div class="summary-operator minus">
-              <span>-</span>
-            </div>
-            <div class="summary-item">
-              <span class="summary-label">상품 할인</span>
-              <span class="summary-value" id="discountPrice">0<span class="unit">원</span></span>
-            </div>
-            <div class="summary-operator plus">
-              <span>+</span>
-            </div>
-            <div class="summary-item">
-              <span class="summary-label">배송비</span>
-              <span class="summary-value" id="shippingFee">0<span class="unit">원</span></span>
-            </div>
-            <div class="summary-result">
-              <span class="result-label">결제 예정 금액</span>
-              <span class="result-value" id="totalPrice">0<span class="unit">원</span></span>
-            </div>
+        <div class="cart-summary">
+          <div class="summary-item">
+            <span class="summary-label">총 상품금액</span>
+            <span class="summary-value" id="totalProductPrice">0<span class="unit">원</span></span>
           </div>
-        </div>
-      </div>
-
-      <!-- Order Button -->
-      <div class="container order-btn-wrapper">
-        <button type="button" class="order-btn-main" id="orderBtn">주문하기</button>
-      </div>
-    </main>
-
-    <!-- 삭제 확인 모달 -->
-    <div class="delete-modal-overlay" id="deleteModal">
-      <div class="delete-modal">
-        <button type="button" class="delete-modal-close" id="deleteModalClose">
-          <img src="../assets/images/icon-delete.svg" alt="닫기" width="22" height="22" />
-        </button>
-        <div class="delete-modal-content">
-          <p>상품을 삭제하시겠습니까?</p>
-        </div>
-        <div class="delete-modal-buttons">
-          <button type="button" class="btn-modal-cancel" id="btnDeleteCancel">취소</button>
-          <button type="button" class="btn-modal-confirm" id="btnDeleteConfirm">확인</button>
+          <div class="summary-operator minus">
+            <span>-</span>
+          </div>
+          <div class="summary-item">
+            <span class="summary-label">상품 할인</span>
+            <span class="summary-value" id="discountPrice">0<span class="unit">원</span></span>
+          </div>
+          <div class="summary-operator plus">
+            <span>+</span>
+          </div>
+          <div class="summary-item">
+            <span class="summary-label">배송비</span>
+            <span class="summary-value" id="shippingFee">0<span class="unit">원</span></span>
+          </div>
+          <div class="summary-result">
+            <span class="result-label">결제 예정 금액</span>
+            <span class="result-value" id="totalPrice">0<span class="unit">원</span></span>
+          </div>
         </div>
       </div>
     </div>
 
-    <!-- Footer -->
-    <div id="footer-container"></div>
+    <!-- Order Button -->
+    <div class="container order-btn-wrapper">
+      <button type="button" class="order-btn-main" id="orderBtn">주문하기</button>
+    </div>
+  </main>
 
-    <script src="../assets/js/common.js" defer></script>
-    <script src="../assets/js/pages/cart.js" defer></script>
-    <script>
+  <!-- 삭제 확인 모달 -->
+  <div class="delete-modal-overlay" id="deleteModal">
+    <div class="delete-modal">
+      <button type="button" class="delete-modal-close" id="deleteModalClose">
+        <img src="../assets/images/icon-delete.svg" alt="닫기" width="22" height="22" />
+      </button>
+      <div class="delete-modal-content">
+        <p>상품을 삭제하시겠습니까?</p>
+      </div>
+      <div class="delete-modal-buttons">
+        <button type="button" class="btn-modal-cancel" id="btnDeleteCancel">취소</button>
+        <button type="button" class="btn-modal-confirm" id="btnDeleteConfirm">확인</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Footer -->
+  <footer id="footer-container"></footer>
+
+  <script src="../assets/js/common.js" defer></script>
+  <script src="../assets/js/pages/cart.js" defer></script>
+  <script>
+    document.addEventListener("DOMContentLoaded", () => {
       loadHeader("../assets/", "cart");
       loadFooter("../assets/");
-    </script>
-  </body>
+    });
+  </script>
+</body>
+
 </html>

--- a/product-detail/index.html
+++ b/product-detail/index.html
@@ -1,190 +1,145 @@
 <!DOCTYPE html>
 <html lang="ko-KR">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>상품 상세 | HODU</title>
-    <link rel="stylesheet" href="../assets/css/reset.css" />
-    <link rel="stylesheet" href="../assets/css/font.css" />
-    <link rel="stylesheet" href="../assets/css/root.css" />
-    <link rel="stylesheet" href="../assets/css/common.css" />
-    <link rel="stylesheet" href="../assets/css/pages/product-detail.css" />
-  </head>
-  <body>
-    <!-- Header -->
-    <div id="header-container"></div>
 
-    <main>
-      <div class="container">
-        <section class="product-detail">
-          <h2 class="scr-only">상품 상세 정보</h2>
+<head>
+  <meta charset="UTF-8" />
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>상품 상세 | HODU</title>
+  <link rel="stylesheet" href="../assets/css/reset.css" />
+  <link rel="stylesheet" href="../assets/css/font.css" />
+  <link rel="stylesheet" href="../assets/css/root.css" />
+  <link rel="stylesheet" href="../assets/css/common.css" />
+  <link rel="stylesheet" href="../assets/css/pages/product-detail.css" />
+</head>
 
-          <div class="product-img">
-            <img
-              src=""
-              alt="딥러닝 개발자 무릎 담요 제품 이미지"
-              width="600"
-              height="600"
-              fetchpriority="high"
-            />
-          </div>
+<body>
+  <!-- Header -->
+  <header id="header-container"></header>
 
-          <div class="product-info">
-            <div class="info-top">
-              <p class="store-name">백엔드글로벌</p>
-              <h3 class="product-tit">딥러닝 개발자 무릎 담요</h3>
-              <p class="product-price">17,500<span class="unit">원</span></p>
-              <p class="delivery-info">택배배송 / 무료배송</p>
+  <main>
+    <div class="container">
+      <section class="product-detail">
+        <h2 class="scr-only">상품 상세 정보</h2>
 
-              <hr class="divider" />
+        <div class="product-img">
+          <img src="" alt="딥러닝 개발자 무릎 담요 제품 이미지" width="600" height="600" fetchpriority="high" />
+        </div>
 
-              <div class="quantity-selector">
-                <button type="button" class="minus">
-                  <img
-                    src="../assets/images/icon-minus-line.svg"
-                    alt="수량 감소"
-                    width="20"
-                    height="20"
-                  />
-                </button>
-                <input type="number" value="1" />
-                <button type="button" class="plus">
-                  <img
-                    src="../assets/images/icon-plus-line.svg"
-                    alt="수량 증가"
-                    width="20"
-                    height="20"
-                  />
-                </button>
-              </div>
+        <div class="product-info">
+          <div class="info-top">
+            <p class="store-name">백엔드글로벌</p>
+            <h3 class="product-tit">딥러닝 개발자 무릎 담요</h3>
+            <p class="product-price">17,500<span class="unit">원</span></p>
+            <p class="delivery-info">택배배송 / 무료배송</p>
 
-              <hr class="divider" />
+            <hr class="divider" />
+
+            <div class="quantity-selector">
+              <button type="button" class="minus">
+                <img src="../assets/images/icon-minus-line.svg" alt="수량 감소" width="20" height="20" />
+              </button>
+              <input type="number" value="1" />
+              <button type="button" class="plus">
+                <img src="../assets/images/icon-plus-line.svg" alt="수량 증가" width="20" height="20" />
+              </button>
             </div>
 
-            <div class="info-bottom">
-              <div class="total-price-wrap">
-                <span class="total-label">총 상품 금액</span>
-                <div class="total-data">
-                  <span class="total-count">총 수량 <strong>1</strong>개</span>
-                  <div class="price-wrap">
-                    <span class="total-price">17,500</span
-                    ><span class="unit-green">원</span>
-                  </div>
+            <hr class="divider" />
+          </div>
+
+          <div class="info-bottom">
+            <div class="total-price-wrap">
+              <span class="total-label">총 상품 금액</span>
+              <div class="total-data">
+                <span class="total-count">총 수량 <strong>1</strong>개</span>
+                <div class="price-wrap">
+                  <span class="total-price">17,500</span><span class="unit-green">원</span>
                 </div>
               </div>
+            </div>
 
-              <div class="action-buttons">
-                <button type="button" class="btn-buy">바로 구매</button>
-                <button type="button" class="btn-cart">장바구니</button>
-              </div>
+            <div class="action-buttons">
+              <button type="button" class="btn-buy">바로 구매</button>
+              <button type="button" class="btn-cart">장바구니</button>
             </div>
           </div>
-        </section>
+        </div>
+      </section>
 
-        <nav class="product-tabs">
-          <ul class="tab-list" role="tablist">
-            <li class="active" role="presentation">
-              <a href="#detail" role="tab" aria-selected="true" data-tab="detail">버튼</a>
-            </li>
-            <li role="presentation">
-              <a href="#review" role="tab" aria-selected="false" data-tab="review">리뷰</a>
-            </li>
-            <li role="presentation">
-              <a href="#qna" role="tab" aria-selected="false" data-tab="qna">Q&A</a>
-            </li>
-            <li role="presentation">
-              <a href="#return" role="tab" aria-selected="false" data-tab="return">반품/교환정보</a>
-            </li>
-          </ul>
-        </nav>
+      <nav class="product-tabs">
+        <ul class="tab-list" role="tablist">
+          <li class="active" role="presentation">
+            <a href="#detail" role="tab" aria-selected="true" data-tab="detail">버튼</a>
+          </li>
+          <li role="presentation">
+            <a href="#review" role="tab" aria-selected="false" data-tab="review">리뷰</a>
+          </li>
+          <li role="presentation">
+            <a href="#qna" role="tab" aria-selected="false" data-tab="qna">Q&A</a>
+          </li>
+          <li role="presentation">
+            <a href="#return" role="tab" aria-selected="false" data-tab="return">반품/교환정보</a>
+          </li>
+        </ul>
+      </nav>
 
+    </div>
+  </main>
+
+  <!-- 장바구니 중복 모달 -->
+  <div class="cart-duplicate-modal-overlay" id="cartDuplicateModal">
+    <div class="cart-duplicate-modal">
+      <button type="button" class="cart-duplicate-modal-close" id="cartDuplicateModalClose">
+        <img src="../assets/images/icon-delete.svg" alt="닫기" width="22" height="22" />
+      </button>
+      <div class="cart-duplicate-modal-content">
+        <p>이미 장바구니에 있는 상품입니다.<br />장바구니로 이동하시겠습니까?</p>
       </div>
-    </main>
-
-    <!-- 장바구니 중복 모달 -->
-    <div class="cart-duplicate-modal-overlay" id="cartDuplicateModal">
-      <div class="cart-duplicate-modal">
-        <button
-          type="button"
-          class="cart-duplicate-modal-close"
-          id="cartDuplicateModalClose"
-        >
-          <img
-            src="../assets/images/icon-delete.svg"
-            alt="닫기"
-            width="22"
-            height="22"
-          />
+      <div class="cart-duplicate-modal-buttons">
+        <button type="button" class="btn-modal-no" id="btnDuplicateModalNo">
+          아니오
         </button>
-        <div class="cart-duplicate-modal-content">
-          <p>이미 장바구니에 있는 상품입니다.<br />장바구니로 이동하시겠습니까?</p>
-        </div>
-        <div class="cart-duplicate-modal-buttons">
-          <button type="button" class="btn-modal-no" id="btnDuplicateModalNo">
-            아니오
-          </button>
-          <button
-            type="button"
-            class="btn-modal-yes"
-            id="btnDuplicateModalYes"
-          >
-            예
-          </button>
-        </div>
+        <button type="button" class="btn-modal-yes" id="btnDuplicateModalYes">
+          예
+        </button>
       </div>
     </div>
+  </div>
 
-    <!-- 장바구니 추가 성공 모달 -->
-    <div
-      class="cart-add-success-modal-overlay"
-      id="cartAddSuccessModal"
-    >
-      <div class="cart-add-success-modal">
-        <button
-          type="button"
-          class="cart-add-success-modal-close"
-          id="cartAddSuccessModalClose"
-        >
-          <img
-            src="../assets/images/icon-delete.svg"
-            alt="닫기"
-            width="22"
-            height="22"
-          />
+  <!-- 장바구니 추가 성공 모달 -->
+  <div class="cart-add-success-modal-overlay" id="cartAddSuccessModal">
+    <div class="cart-add-success-modal">
+      <button type="button" class="cart-add-success-modal-close" id="cartAddSuccessModalClose">
+        <img src="../assets/images/icon-delete.svg" alt="닫기" width="22" height="22" />
+      </button>
+      <div class="cart-add-success-modal-content">
+        <p>
+          장바구니에 상품을 담았습니다.<br />장바구니로 이동하시겠습니까?
+        </p>
+      </div>
+      <div class="cart-add-success-modal-buttons">
+        <button type="button" class="btn-modal-no" id="btnAddSuccessModalNo">
+          아니오
         </button>
-        <div class="cart-add-success-modal-content">
-          <p>
-            장바구니에 상품을 담았습니다.<br />장바구니로 이동하시겠습니까?
-          </p>
-        </div>
-        <div class="cart-add-success-modal-buttons">
-          <button
-            type="button"
-            class="btn-modal-no"
-            id="btnAddSuccessModalNo"
-          >
-            아니오
-          </button>
-          <button
-            type="button"
-            class="btn-modal-yes"
-            id="btnAddSuccessModalYes"
-          >
-            예
-          </button>
-        </div>
+        <button type="button" class="btn-modal-yes" id="btnAddSuccessModalYes">
+          예
+        </button>
       </div>
     </div>
+  </div>
 
-    <!-- footer -->
-    <div id="footer-container"></div>
+  <!-- footer -->
+  <footer id="footer-container"></footer>
 
-    <script src="../assets/js/common.js" defer></script>
-    <script src="../assets/js/pages/product-detail.js" defer></script>
-    <script>
+  <script src="../assets/js/common.js" defer></script>
+  <script src="../assets/js/pages/product-detail.js" defer></script>
+  <script>
+    document.addEventListener("DOMContentLoaded", () => {
       loadHeader("../assets/");
       loadFooter("../assets/");
-    </script>
-  </body>
+    });
+  </script>
+</body>
+
 </html>


### PR DESCRIPTION
상품페이지, 장바구니에서 헤더와 푸터가 없어지는 문제 수정했습니다.





-----------------------------------
# 작업 확인 문서 (Walkthrough) - 헤더/푸터 로딩 문제 수정

장바구니(Cart)와 상품 상세(Product Detail) 페이지에서 상단 헤더와 하단 푸터가 나타나지 않던 문제를 수정했습니다.

## 변경 사항

### [cart/index.html](file:///c:/FrontendWORK/team-proj02/openMarketService/cart/index.html) 및 [product-detail/index.html](file:///c:/FrontendWORK/team-proj02/openMarketService/product-detail/index.html)

1.  **DOMContentLoaded 래퍼 추가**: `defer` 속성으로 로드되는 `common.js`가 준비되고 DOM이 완전히 로드된 시점에 `loadHeader`와 `loadFooter`가 실행되도록 이벤트 리스너를 추가했습니다.
2.  **시맨틱 태그 적용**: 기존의 `<div>` 태그를 `<header>`와 `<footer>` 태그로 변경하여 웹 접근성을 높이고 메인 페이지와의 일관성을 맞췄습니다.

```html
<!-- 수정 전 -->
<div id="header-container"></div>
<script>
  loadHeader("../assets/", "cart");
  loadFooter("../assets/");
</script>

<!-- 수정 후 -->
<header id="header-container"></header>
<script>
  document.addEventListener("DOMContentLoaded", () => {
    loadHeader("../assets/", "cart");
    loadFooter("../assets/");
  });
</script>
```

## 검증 결과

- **장바구니 페이지**: 헤더와 푸터가 정상적으로 로드되며, 장바구니 아이콘이 활성화 상태(초록색)로 표시됩니다.
- **상품 상세 페이지**: 헤더와 푸터가 정상적으로 로드됩니다.
- **일관성**: 모든 페이지가 공통 컴포넌트를 로드하는 표준화된 방식을 사용하게 되었습니다.
